### PR TITLE
Amended file extension handling in 'hash' mode

### DIFF
--- a/dist/CordovaFileCache.js
+++ b/dist/CordovaFileCache.js
@@ -294,7 +294,10 @@ var CordovaFileCache =
 	      return this.localRoot + url.substr(len);
 	    }
 	  } else {
-	    return this.localRoot + hash(url) + url.substr(url.lastIndexOf('.'));
+	    var ext = url.substr(url.lastIndexOf('.'));
+	      ext = ".txt";
+	    }
+	    return this.localRoot + hash(url) + ext;
 	  }
 	};
 

--- a/dist/CordovaFileCache.js
+++ b/dist/CordovaFileCache.js
@@ -295,6 +295,7 @@ var CordovaFileCache =
 	    }
 	  } else {
 	    var ext = url.substr(url.lastIndexOf('.'));
+	    if ((ext.indexOf("?") > 0) || (ext.indexOf("/") > 0)) {
 	      ext = ".txt";
 	    }
 	    return this.localRoot + hash(url) + ext;

--- a/index.js
+++ b/index.js
@@ -247,7 +247,11 @@ FileCache.prototype.toPath = function toPath(url){
       return this.localRoot + url.substr(len);
     }
   } else {
-    return this.localRoot + hash(url) + url.substr(url.lastIndexOf('.'));
+    var ext = url.substr(url.lastIndexOf('.'));
+    if ((ext.indexOf("?") > 0) || (ext.indexOf("/") > 0)) {
+      ext = ".txt";
+    }
+    return this.localRoot + hash(url) + ext;
   }
 };
 


### PR DESCRIPTION
This was done to improve compatibility with some URL formats such as REST API `http://domain.com/api/user?id=1`

Please note that the version number was not amended.  Thus it needs to be updated manually if merged.