### PR TITLE
Fix issue where len was undefined in strict mode

### DIFF
--- a/dist/CordovaFileCache.js
+++ b/dist/CordovaFileCache.js
@@ -290,7 +290,7 @@ var CordovaFileCache =
 	      url = url.substr(0,query);
 	    }
 	    url = url = this._fs.normalize(url || '');
-	    len = this.serverRoot.length;
+	    var len = this.serverRoot.length;
 	    if(url.substr(0,len) !== this.serverRoot) {
 	      return this.localRoot + url;
 	    } else {

--- a/index.js
+++ b/index.js
@@ -243,7 +243,7 @@ FileCache.prototype.toPath = function toPath(url){
       url = url.substr(0,query);
     }
     url = url = this._fs.normalize(url || '');
-    len = this.serverRoot.length;
+    var len = this.serverRoot.length;
     if(url.substr(0,len) !== this.serverRoot) {
       return this.localRoot + url;
     } else {


### PR DESCRIPTION
When webpacking and transpiling with babel, this code can fall into a section that include "use strict". I've only found one problem with that, which is this line.