### PR TITLE
Fix hash mode filenames with query strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -259,8 +259,11 @@ FileCache.prototype.toPath = function toPath(url){
     }
   } else {
     var ext = url.substr(url.lastIndexOf('.'));
-    if ((ext.indexOf("?") > 0) || (ext.indexOf("/") > 0)) {
-      ext = ".txt";
+    if (ext.indexOf('?') > 0) {
+      ext = ext.substr(0, ext.indexOf('?'))
+    }
+    if (ext.indexOf('/') > 0) {
+      ext = ext.substr(0, ext.indexOf('/'))
     }
     return this.localRoot + hash(url) + ext;
   }


### PR DESCRIPTION
Instead of just using `.txt`, filenames should try and use the extension of the original file, leaving out query strings.