### PR TITLE
Fix 'not a function' errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,7 +136,7 @@ FileCache.prototype.download = function download(onprogress,includeFileProgressE
       queue.forEach(function(url){
         var path = self.toPath(url);
         // augment progress event with done/total stats
-        var onSingleDownloadProgress;
+        var onSingleDownloadProgress = function() {};
         if(typeof onprogress === 'function') {
           onSingleDownloadProgress = function(ev){
             ev.queueIndex = done;


### PR DESCRIPTION
Since onSingleDownloadProgress gets called as a function, it has to be defined as *something* to avoid causing exceptions.