### PR TITLE
cordova-plugin-file-transfer is required for dl

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Based on [cordova-promise-fs](https://github.com/markmarijnissen/cordova-promise
   # install Cordova and plugins
   cordova platform add ios
   cordova plugin add cordova-plugin-file
-  cordova plugin add cordova-plugin-file-transfer # optional
+  cordova plugin add cordova-plugin-file-transfer # required to download files
 ```
 
 **IMPORTANT:** For iOS, use Cordova 3.7.0 or higher (due to a [bug](https://github.com/AppGyver/steroids/issues/534) that affects requestFileSystem).


### PR DESCRIPTION
If #5 is correct, then the `cordova-plugin-file-transfer` is required to download files. Indeed, I was not able to download files until I added the plugin. Figure this tweak to the README makes that a little clearer, but please feel free to reject / modify / etc as you see fit. I'm really just starting out with the plugin, so no idea if what I wrote is really true or not!