### PR TITLE
fix extension types with numbers not working

### DIFF
--- a/index.js
+++ b/index.js
@@ -258,7 +258,7 @@ FileCache.prototype.toPath = function toPath(url){
       return this.localRoot + url.substr(len);
     }
   } else {
-    var ext = url.match(/\.[a-z]{1,}/g);
+    var ext = url.match(/\.[a-z,0-9]{1,}/g);
     if (ext) {
       ext = ext[ext.length-1];
     } else {


### PR DESCRIPTION
Based on the issue #30, files like `.mp3` and `.mp4` get downloaded, but the local url changed to `.mp` sans the number, and are subsequently not found when requested with `.get()`